### PR TITLE
Add unit support for read/write calls

### DIFF
--- a/fatek/fatek.py
+++ b/fatek/fatek.py
@@ -20,17 +20,17 @@ class Fatek(object):
         self.address = address
         self.client = ModbusTcpClient(address, port)
 
-    def read(self, symbol):
-        target = FatekTarget(self.client, symbol)
+    def read(self, symbol, unit=0x00):
+        target = FatekTarget(self.client, symbol, unit)
         return target.read()
 
-    def write(self, symbol, value=True):
-        target = FatekTarget(self.client, symbol)
+    def write(self, symbol, unit=0x00, value=True):
+        target = FatekTarget(self.client, symbol, unit)
         return target.write(value)
 
-    def bulk_read(self, symbol, count, current_value=False):
+    def bulk_read(self, symbol, count, unit=0x00, current_value=False):
         """
             current_value is for reading numeric values from T and C registers
         """
-        target = FatekTarget(self.client, symbol, current_value)
+        target = FatekTarget(self.client, symbol, unit, current_value)
         return target.read_all(int(count))

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -26,25 +26,49 @@ class TestTarget(TestCase):
         FatekTarget(self.client, 'R333').read()
         self.client.read_holding_registers.assert_called_once_with(333, 1)
 
+    def test_R333_with_unit(self):
+        FatekTarget(self.client, 'R333', unit=0x01).read()
+        self.client.read_holding_registers.assert_called_once_with(333, 1, unit=0x01)
+
     def test_D333(self):
         FatekTarget(self.client, 'D333').write(593)
         self.client.write_register.assert_called_once_with(6333, 593)
+
+    def test_D333_with_unit(self):
+        FatekTarget(self.client, 'D333', unit=0x01).write(593)
+        self.client.write_register.assert_called_once_with(6333, 593, unit=0x01)
 
     def test_T255c(self):
         FatekTarget(self.client, 'T255', current_value=False).read()
         self.client.read_coils.assert_called_once_with(9255, 1)
 
+    def test_T255c_with_unit(self):
+        FatekTarget(self.client, 'T255', unit=0x01, current_value=False).read()
+        self.client.read_coils.assert_called_once_with(9255, 1, unit=0x01)
+
     def test_T255r(self):
         FatekTarget(self.client, 'T255', current_value=True).read()
         self.client.read_holding_registers.assert_called_once_with(9255, 1)
+
+    def test_T255r(self):
+        FatekTarget(self.client, 'T255', unit=0x01, current_value=True).read()
+        self.client.read_holding_registers.assert_called_once_with(9255, 1, unit=0x01)
 
     def test_M300_readall(self):
         FatekTarget(self.client, 'M300').read_all(50)
         self.client.read_coils.assert_called_once_with(2300, 50)
 
+    def test_M300_readall_with_unit(self):
+        FatekTarget(self.client, 'M300', unit=0x01).read_all(50)
+        self.client.read_coils.assert_called_once_with(2300, 50, unit=0x01)
+
     def test_R300_readall(self):
         FatekTarget(self.client, 'R300').read_all(55)
         self.client.read_holding_registers.assert_called_once_with(300, 55)
+
+    def test_R300_readall_with_unit(self):
+        FatekTarget(self.client, 'R300', unit=0x01).read_all(55)
+        self.client.read_holding_registers.assert_called_once_with(300, 55, unit=0x01)
 
     def test_coil_range_2000(self):
         with self.assertRaises(InvalidTargetError):


### PR DESCRIPTION
I've come across a few PLC's which do not respond to the global id (0x00) which implies all slaves should answer. Therefore we need to add support for the unit param that's already supported in pymodbus.

I'll only have access to a real PLC again in a few weeks to properly test, so feedback is appreciated.